### PR TITLE
wp-load.php require with alternative file structures

### DIFF
--- a/require/dynamic.php
+++ b/require/dynamic.php
@@ -1,25 +1,25 @@
 <?php  
  
- // If using the default WordPress file structure
- if (file_exists('../../../../wp-load.php')) {
- 	// Make WordPress functions and methods available
- 	require '../../../../wp-load.php';
+// If using the default WordPress file structure
+if (file_exists('../../../../wp-load.php')) {
+    // Make WordPress functions and methods available
+    require '../../../../wp-load.php';
 
- // If using alternative WordPress file structure like Roots' Bedrock
- } else {
- 	// WP's constant ABSPATH is not available, so use $_SERVER['DOCUMENT_ROOT'] to get the web root
- 	$directory = new RecursiveDirectoryIterator($_SERVER['DOCUMENT_ROOT']);
+// If using alternative WordPress file structure like Roots' Bedrock
+} else {
+    // WP's constant ABSPATH is not available, so use $_SERVER['DOCUMENT_ROOT'] to get the web root
+    $directory = new RecursiveDirectoryIterator($_SERVER['DOCUMENT_ROOT']);
 
- 	// Recursively search web root for wp-load.php
- 	foreach (new RecursiveIteratorIterator($directory) as $file) {
- 		// wp-load.php found, require and break loop
- 		if ($file->getFilename() === 'wp-load.php') {
- 			// Make WordPress functions and methods available
- 			require $file->getPathname();
- 			break;
- 		}
- 	}
- }
+    // Recursively search web root for wp-load.php
+    foreach (new RecursiveIteratorIterator($directory) as $file) {
+        // wp-load.php found, require and break loop
+        if ($file->getFilename() === 'wp-load.php') {
+            // Make WordPress functions and methods available
+            require $file->getPathname();
+            break;
+        }
+    }
+}
  
  $themes = get_option('agca_templates');	
  $selectedTheme = get_option('agca_selected_template');

--- a/require/dynamic.php
+++ b/require/dynamic.php
@@ -1,5 +1,25 @@
 <?php  
- require '../../../../wp-load.php';  
+ 
+ // If using the default WordPress file structure
+ if (file_exists('../../../../wp-load.php')) {
+ 	// Make WordPress functions and methods available
+ 	require '../../../../wp-load.php';
+
+ // If using alternative WordPress file structure like Roots' Bedrock
+ } else {
+ 	// WP's constant ABSPATH is not available, so use $_SERVER['DOCUMENT_ROOT'] to get the web root
+ 	$directory = new RecursiveDirectoryIterator($_SERVER['DOCUMENT_ROOT']);
+
+ 	// Recursively search web root for wp-load.php
+ 	foreach (new RecursiveIteratorIterator($directory) as $file) {
+ 		// wp-load.php found, require and break loop
+ 		if ($file->getFilename() === 'wp-load.php') {
+ 			// Make WordPress functions and methods available
+ 			require $file->getPathname();
+ 			break;
+ 		}
+ 	}
+ }
  
  $themes = get_option('agca_templates');	
  $selectedTheme = get_option('agca_selected_template');


### PR DESCRIPTION
## Reason
<!-- Replace the space between the [] with an x to denote what the PR is for -->
- [ ] Bug Fix
- [x] Feature Add/Remove
- [ ] Refactor (cleanup, add comments, etc.)
- [ ] Updates (dependencies, plugins, or other packages)

## Issue
<!-- Bullets of what needed to be changed -->
- While using alternative file structures for WordPress the require of wp-load.php throws an error

## Resolution
<!-- Bullets of what was changed or added -->
- Made the require more flexible by checking if the file exists first and if not then recursively searching the web root directory for wp-load.php and requiring it.

___

### Notes
<!-- Any information that may be useful for others -->
<!-- Changes to existing methods or useful functions that were added etc. -->
- This was specifically an issue using [Roots' Bedrock](https://github.com/roots/bedrock)